### PR TITLE
Feat: 백테스팅 UI 레이아웃 변경

### DIFF
--- a/src/components/backtesting/BasicSetup.tsx
+++ b/src/components/backtesting/BasicSetup.tsx
@@ -1,8 +1,9 @@
-import styled from "styled-components";
-import SetupTitle from "../common/SetupTitle";
 import Input from "@/components/common/Input";
-import InputWithDropdown from "@/components/common/InputWithDropdown";
 import InputWithCalendar from "@/components/common/InputWithCalendar";
+import InputWithDropdown from "@/components/common/InputWithDropdown";
+import styled from "styled-components";
+import MyStrategyButton from "../common/MyStrategyButton";
+import SetupTitle from "../common/SetupTitle";
 
 const REBALANCING_OPTIONS = [
   { value: 0, name: "1년마다 한번" },
@@ -44,20 +45,26 @@ const BasicSetup = () => {
           <LabelStyle>수수료</LabelStyle>
           <Input type="number" unit="%" defaultValue="0.02" />
         </InputWithLabel>
+        <MyStrategyButton schema="myStrategy" />
       </BasicSetupForm>
     </BasicSetupStyle>
   );
 };
 
-const BasicSetupStyle = styled.div``;
+const BasicSetupStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
 const BasicSetupForm = styled.form`
+  flex: 1;
+  border-radius: 0 0 1.25rem 1.25rem;
   background-color: #ffffff;
-  height: 720px;
-  width: 388px;
   display: flex;
   flex-wrap: wrap;
   gap: 24px 0;
   padding: 24px 32px;
+  overflow-y: auto;
 `;
 
 const InputWithLabel = styled.div`

--- a/src/components/backtesting/FactorDropdown.tsx
+++ b/src/components/backtesting/FactorDropdown.tsx
@@ -64,7 +64,7 @@ const FactorDropdown = ({
 };
 
 const FactorDropdownStyle = styled.div<{ $open: boolean }>`
-  background: #fff;
+  background: #fbfaff;
   cursor: pointer;
 
   .select-box {

--- a/src/components/backtesting/FactorDropdown.tsx
+++ b/src/components/backtesting/FactorDropdown.tsx
@@ -1,8 +1,8 @@
-import styled from "styled-components";
 import ArrowDownSVG from "@/assets/images/arrowDown.svg?react";
 import { useState } from "react";
-import FactorItem from "./FactorItem";
+import styled from "styled-components";
 import ToolTip from "../common/ToolTip";
+import FactorItem from "./FactorItem";
 
 interface Option {
   id: number;
@@ -66,6 +66,7 @@ const FactorDropdown = ({
 const FactorDropdownStyle = styled.div<{ $open: boolean }>`
   background: #fff;
   cursor: pointer;
+
   .select-box {
     display: flex;
     justify-content: space-between;

--- a/src/components/backtesting/FactorSetup.tsx
+++ b/src/components/backtesting/FactorSetup.tsx
@@ -1,7 +1,7 @@
+import { FACTOR_STRATEGY_LIST } from "@/constants/backtest";
+import { useState } from "react";
 import styled from "styled-components";
 import SetupTitle from "../common/SetupTitle";
-import { useState } from "react";
-import { FACTOR_STRATEGY_LIST } from "@/constants/backtest";
 import FactorDropdown from "./FactorDropdown";
 
 const FactorSetup = () => {
@@ -22,21 +22,23 @@ const FactorSetup = () => {
   return (
     <FactorSetupStyle>
       <SetupTitle title="팩터 설정" info="*복수선택 가능" />
-      <FactorDropdown
-        title="가치"
-        titleInfo="가치란?"
-        options={FACTOR_STRATEGY_LIST.value}
-        optionsActive={optionsActive}
-        onCheck={handleOptionsActive}
-        open
-      />
-      <FactorDropdown
-        title="수익성"
-        titleInfo="수익성이란?"
-        options={FACTOR_STRATEGY_LIST.profit}
-        optionsActive={optionsActive}
-        onCheck={handleOptionsActive}
-      />
+      <Choice>
+        <FactorDropdown
+          title="가치"
+          titleInfo="가치란?"
+          options={FACTOR_STRATEGY_LIST.value}
+          optionsActive={optionsActive}
+          onCheck={handleOptionsActive}
+          open
+        />
+        <FactorDropdown
+          title="수익성"
+          titleInfo="수익성이란?"
+          options={FACTOR_STRATEGY_LIST.profit}
+          optionsActive={optionsActive}
+          onCheck={handleOptionsActive}
+        />
+      </Choice>
       <div className="empty-bottom"></div>
     </FactorSetupStyle>
   );
@@ -54,4 +56,9 @@ const FactorSetupStyle = styled.div`
   }
 `;
 
+const Choice = styled.div`
+  overflow-x: hidden;
+  overflow-y: auto;
+  max-height: 448px;
+`;
 export default FactorSetup;

--- a/src/components/backtesting/FactorSetup.tsx
+++ b/src/components/backtesting/FactorSetup.tsx
@@ -59,6 +59,6 @@ const FactorSetupStyle = styled.div`
 const Choice = styled.div`
   overflow-x: hidden;
   overflow-y: auto;
-  max-height: 448px;
+  max-height: 360px;
 `;
 export default FactorSetup;

--- a/src/components/backtesting/MiddleSetup.tsx
+++ b/src/components/backtesting/MiddleSetup.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import FactorSetup from "./FactorSetup";
+import TechnicalAnalysisStrategySetup from "./TechnicalAnalysisStrategySetup";
+
+const MiddleSetup = () => {
+  return (
+    <MiddleSetupStyle>
+      <FactorSetup />
+      <TechnicalAnalysisStrategySetup />
+    </MiddleSetupStyle>
+  );
+};
+
+const MiddleSetupStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+export default MiddleSetup;

--- a/src/components/backtesting/MiddleSetup.tsx
+++ b/src/components/backtesting/MiddleSetup.tsx
@@ -15,5 +15,6 @@ const MiddleSetupStyle = styled.div`
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+  height: 100%;
 `;
 export default MiddleSetup;

--- a/src/components/backtesting/TechnicalAnalysisStrategySetup.tsx
+++ b/src/components/backtesting/TechnicalAnalysisStrategySetup.tsx
@@ -1,9 +1,8 @@
+import { FACTOR_STRATEGY_LIST } from "@/constants/backtest";
+import { useState } from "react";
 import styled from "styled-components";
 import SetupTitle from "../common/SetupTitle";
-import { useState } from "react";
-import { FACTOR_STRATEGY_LIST } from "@/constants/backtest";
 import FactorItem from "./FactorItem";
-import { OptionContainer } from "./FactorDropdown";
 
 const TechnicalAnalysisStrategySetup = () => {
   const [optionsActive, setOptionsActive] = useState<number[]>([]);
@@ -43,6 +42,10 @@ const TechnicalAnalysisStrategySetup = () => {
 };
 
 const TechnicalAnalysisStrategySetupStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
   border-radius: 1.125rem;
   border: 1px solid ${({ theme }) => theme.color.gray3};
   background-color: #fff;
@@ -54,6 +57,16 @@ const TechnicalAnalysisStrategySetupStyle = styled.div`
   .empty-bottom {
     height: 16px;
     border-radius: 0 0 1.125rem 1.125rem;
+  }
+`;
+
+const OptionContainer = styled.div`
+  overflow-y: auto;
+  ul,
+  li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 `;
 export default TechnicalAnalysisStrategySetup;

--- a/src/components/backtesting/TechnicalAnalysisStrategySetup.tsx
+++ b/src/components/backtesting/TechnicalAnalysisStrategySetup.tsx
@@ -44,7 +44,8 @@ const TechnicalAnalysisStrategySetup = () => {
 const TechnicalAnalysisStrategySetupStyle = styled.div`
   display: flex;
   flex-direction: column;
-  flex: 1;
+  flex-grow: 1;
+  overflow-y: hidden;
 
   border-radius: 1.125rem;
   border: 1px solid ${({ theme }) => theme.color.gray3};

--- a/src/components/common/SetupTitle.tsx
+++ b/src/components/common/SetupTitle.tsx
@@ -14,6 +14,7 @@ const SetupTitle = ({ title, info }: Props) => {
 };
 
 const SetupTitleStyle = styled.div`
+  flex-shrink: 0;
   height: 4.5rem;
   color: ${({ theme }) => theme.color.white};
   background: ${({ theme }) => theme.color.sub5};

--- a/src/components/common/navbar/NavBar.tsx
+++ b/src/components/common/navbar/NavBar.tsx
@@ -21,8 +21,8 @@ const SNB_ITEM = [
     path: "/backtesting"
   },
   { icon: <SnbMockInvestSVG />, name: "모의투자", path: "/test" },
-  { icon: <SnbMarketSVG />, name: "마켓", path: "/" },
-  { icon: <SnbDashBoardSVG />, name: "MY 대시보드", path: "/" }
+  { icon: <SnbMarketSVG />, name: "마켓", path: "/market" },
+  { icon: <SnbDashBoardSVG />, name: "MY 대시보드", path: "/my-dashboard" }
 ];
 
 const NavBar = () => {

--- a/src/pages/BackTesting.tsx
+++ b/src/pages/BackTesting.tsx
@@ -20,12 +20,12 @@ const BackTestingStyle = styled.div`
   padding: 1.5rem;
   display: flex;
   gap: 1.5rem;
-  min-height: calc(100vh - 124px);
+  height: calc(100vh - 124px);
   background-color: ${({ theme }) => theme.color.gray1};
+  overflow-y: hidden;
 
   .setting {
     border-radius: 18px;
-    background-color: white;
   }
 
   .left-setting {
@@ -37,6 +37,7 @@ const BackTestingStyle = styled.div`
 
   .right-setting {
     flex: 1.8;
+    background-color: white;
   }
 `;
 export default BackTesting;

--- a/src/pages/BackTesting.tsx
+++ b/src/pages/BackTesting.tsx
@@ -1,6 +1,5 @@
 import BasicSetup from "@/components/backtesting/BasicSetup";
-import FactorSetup from "@/components/backtesting/FactorSetup";
-import TechnicalAnalysisStrategySetup from "@/components/backtesting/TechnicalAnalysisStrategySetup";
+import MiddleSetup from "@/components/backtesting/MiddleSetup";
 import styled from "styled-components";
 
 const BackTesting = () => {
@@ -10,12 +9,7 @@ const BackTesting = () => {
         <BasicSetup />
       </div>
       <div className="setting middle-setting">
-        <div className="factor-setup">
-          <FactorSetup />
-        </div>
-        <div className="technical-setup">
-          <TechnicalAnalysisStrategySetup />
-        </div>
+        <MiddleSetup />
       </div>
       <div className="setting right-setting"></div>
     </BackTestingStyle>
@@ -31,22 +25,18 @@ const BackTestingStyle = styled.div`
 
   .setting {
     border-radius: 18px;
+    background-color: white;
   }
 
   .left-setting {
-    width: 388px;
-    background-color: white;
+    flex: 1;
   }
   .middle-setting {
-    width: 388px;
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
+    flex: 1;
   }
 
   .right-setting {
-    width: 704px;
-    background-color: white;
+    flex: 1.8;
   }
 `;
 export default BackTesting;


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- 설정 레이아웃을 ```1:1:8```로 변경
- 전체 화면의 높이를 모니터 높이로 변경하며, 각 설정을 스크롤로 조정

### ❗️PR Point
- 부모 컨테이너가 ```overflow:hidden```이라서 툴팁이 보이지 않는 이슈가 있습니다. 좀 더 알아 본 후 수정하겠습니다.
![image](https://github.com/user-attachments/assets/e5b8cd1e-2122-4387-ba7d-82829b906dc1)


### 📸 스크린샷
![화면 캡처 2024-08-13 020604](https://github.com/user-attachments/assets/c82487e4-333a-4da9-8df3-9f69a567fc92)


closed #43 
