### PR TITLE
Design: 내 정보 수정 > 닉네임 변경 및 회원탈퇴 모달 띄우기

### DIFF
--- a/src/components/common/Body.tsx
+++ b/src/components/common/Body.tsx
@@ -1,15 +1,16 @@
 import { TBodySize } from "@/style/theme";
+import { HTMLAttributes } from "react";
 import styled from "styled-components";
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   size: TBodySize;
   color?: string;
 }
 
-const Body = ({ children, size, color }: Props) => {
+const Body = ({ children, size, color, ...props }: Props) => {
   return (
-    <BodyStyle size={size} color={color}>
+    <BodyStyle size={size} color={color} {...props}>
       {children}
     </BodyStyle>
   );

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,15 +1,15 @@
 import { ColorKey, THeadingSize } from "@/style/theme";
-import React from "react";
+import React, { HTMLAttributes } from "react";
 import styled from "styled-components";
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   size: THeadingSize;
   color?: ColorKey;
 }
-const Title = ({ children, size, color }: Props) => {
+const Title = ({ children, size, color, ...props }: Props) => {
   return (
-    <TitleStyle size={size} color={color}>
+    <TitleStyle size={size} color={color} {...props}>
       {children}
     </TitleStyle>
   );

--- a/src/components/common/navbar/NavBar.tsx
+++ b/src/components/common/navbar/NavBar.tsx
@@ -47,7 +47,6 @@ const NavBar = () => {
     http
       .post(MEMBER_API.logout)
       .then(() => {
-        window.alert(`⭕ logout 성공!`);
         dispatch(setLogout());
       })
       .catch((err) => console.log(`❌ ${err}`));
@@ -86,11 +85,13 @@ const NavBar = () => {
           </SnbItemStyle>
         </SnbItemWithTitleStyle>
         <Buttons>
-          <MyInfoButton onClick={myModalOpen}>
-            <Body size="B2" color="white">
-              내 정보 수정
-            </Body>
-          </MyInfoButton>
+          {isLoggedIn && (
+            <MyInfoButton onClick={myModalOpen}>
+              <Body size="B2" color="white">
+                내 정보 수정
+              </Body>
+            </MyInfoButton>
+          )}
           <LoginButton
             onClick={() => handleLog(isLoggedIn ? "logout" : "login")}
           >

--- a/src/components/common/navbar/NavBar.tsx
+++ b/src/components/common/navbar/NavBar.tsx
@@ -63,7 +63,9 @@ const NavBar = () => {
               <SnbItem
                 key={index}
                 text={item.name}
-                schema="default"
+                schema={
+                  location.pathname === item.path ? "selected" : "default"
+                }
                 icon={item.icon}
                 diasbled={false}
                 path={item.path}
@@ -71,6 +73,7 @@ const NavBar = () => {
             ))}
           </SnbItemStyle>
         </SnbItemWithTitleStyle>
+
         <LoginButton onClick={() => handleLog(isLoggedIn ? "logout" : "login")}>
           {isLoggedIn ? "로그아웃" : "로그인"}
         </LoginButton>
@@ -92,7 +95,6 @@ const NavBarStyle = styled.div`
   height: 980px;
   padding: 48px 32px;
   flex-direction: column;
-  align-items: flex-start;
   gap: 448px;
   flex-shrink: 0;
   background: #7467ff;
@@ -129,4 +131,5 @@ const SnbItemStyle = styled.div`
   align-self: stretch;
 `;
 
+const MyInfo = styled.button``;
 export default NavBar;

--- a/src/components/common/navbar/NavBar.tsx
+++ b/src/components/common/navbar/NavBar.tsx
@@ -5,12 +5,14 @@ import SnbDashBoardSVG from "@/assets/images/SnbDashBoard.svg?react";
 import SnbMarketSVG from "@/assets/images/SnbMarket.svg?react";
 import SnbMockInvestSVG from "@/assets/images/SnbMockInvest.svg?react";
 import Modal from "@/components/modal/Modal";
+import MyPageModal from "@/components/modal/MyPageModal";
 import SocialLoginModal from "@/components/modal/SocialLoginModal";
 import { MEMBER_API } from "@/constants/apiPath";
 import { useTypedDispatch, useTypedSelector } from "@/hooks/redux";
 import useModal from "@/hooks/useModal";
 import { setLogout } from "@/store/slices/authSlice";
 import styled from "styled-components";
+import Body from "../Body";
 import LoginButton from "../LoginButton";
 import SnbItem from "./SnbItem";
 
@@ -29,7 +31,17 @@ const NavBar = () => {
   const { isLoggedIn } = useTypedSelector((state) => state.auth);
   const dispatch = useTypedDispatch();
 
-  const { isOpen, modalOpen, modalClose } = useModal(false);
+  const {
+    isOpen: isLoginOpen,
+    modalOpen: loginModalOpen,
+    modalClose: loginModalClose
+  } = useModal(false);
+
+  const {
+    isOpen: isMyOpen,
+    modalOpen: myModalOpen,
+    modalClose: myModalClose
+  } = useModal(false);
 
   const logout = () => {
     http
@@ -44,7 +56,7 @@ const NavBar = () => {
   const handleLog = (type: "login" | "logout") => {
     const handlers = {
       login: () => {
-        modalOpen();
+        loginModalOpen();
       },
       logout: () => {
         logout();
@@ -73,63 +85,80 @@ const NavBar = () => {
             ))}
           </SnbItemStyle>
         </SnbItemWithTitleStyle>
-
-        <LoginButton onClick={() => handleLog(isLoggedIn ? "logout" : "login")}>
-          {isLoggedIn ? "로그아웃" : "로그인"}
-        </LoginButton>
+        <Buttons>
+          <MyInfoButton onClick={myModalOpen}>
+            <Body size="B2" color="white">
+              내 정보 수정
+            </Body>
+          </MyInfoButton>
+          <LoginButton
+            onClick={() => handleLog(isLoggedIn ? "logout" : "login")}
+          >
+            {isLoggedIn ? "로그아웃" : "로그인"}
+          </LoginButton>
+        </Buttons>
       </SnbItemWithTitleAndLoginButtonStyle>
-      {isOpen && (
-        <Modal onClose={modalClose}>
-          <SocialLoginModal onClose={modalClose} />
+      {isLoginOpen && (
+        <Modal onClose={loginModalClose}>
+          <SocialLoginModal onClose={loginModalClose} />
+        </Modal>
+      )}
+      {isMyOpen && (
+        <Modal onClose={myModalClose}>
+          <MyPageModal onClose={myModalClose} />
         </Modal>
       )}
     </NavBarStyle>
   );
 };
 const NavBarStyle = styled.div`
-  display: inline-flex;
   position: fixed;
   top: 0;
   left: 0;
   width: 344px;
-  height: 980px;
+  height: 100vh;
   padding: 48px 32px;
   flex-direction: column;
-  gap: 448px;
   flex-shrink: 0;
   background: #7467ff;
   z-index: 1000;
 `;
 const SnbItemWithTitleAndLoginButtonStyle = styled.div`
   display: flex;
-  height: 884px;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 398px;
   flex-shrink: 0;
-  align-self: stretch;
+  height: 100%;
 `;
 const SnbItemWithTitleStyle = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   gap: 60px;
   .logo {
     display: flex;
     padding-left: 20px;
     flex-direction: column;
-    align-items: flex-start;
     gap: 10px;
-    align-self: stretch;
   }
+  flex: 1;
 `;
 const SnbItemStyle = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   gap: 10px;
-  align-self: stretch;
+`;
+const Buttons = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  button {
+    height: 48px;
+  }
 `;
 
-const MyInfo = styled.button``;
+const MyInfoButton = styled.button`
+  display: flex;
+  align-items: center;
+  padding: 0px 20px;
+`;
+
 export default NavBar;

--- a/src/components/modal/MyPageItem.tsx
+++ b/src/components/modal/MyPageItem.tsx
@@ -1,14 +1,21 @@
+import NextButton from "@/assets/images/NextButton.svg?react";
 import styled from "styled-components";
 import Body from "../common/Body";
-import NextButton from "@/assets/images/NextButton.svg?react";
 interface Props {
   text: string;
   icon?: React.ReactNode;
   buttonText: string;
   isConnected: boolean;
+  onClick?: () => void;
 }
 
-const MyPageItem = ({ text, icon, buttonText, isConnected }: Props) => {
+const MyPageItem = ({
+  text,
+  icon,
+  buttonText,
+  isConnected,
+  onClick
+}: Props) => {
   return (
     <MyPageItemStyle>
       <div className="icon"> {icon}</div>
@@ -16,15 +23,17 @@ const MyPageItem = ({ text, icon, buttonText, isConnected }: Props) => {
         <Body size="B1"> {text}</Body>
       </div>
 
-      {isConnected ? (
-        <Body size="B1" color="#7467FF">
-          {buttonText}
-        </Body>
-      ) : (
-        <div className="icon">
-          <NextButton />
-        </div>
-      )}
+      <button onClick={onClick}>
+        {isConnected ? (
+          <Body size="B1" color="#7467FF">
+            {buttonText}
+          </Body>
+        ) : (
+          <div className="icon">
+            <NextButton />
+          </div>
+        )}
+      </button>
     </MyPageItemStyle>
   );
 };

--- a/src/components/modal/MyPageModal.tsx
+++ b/src/components/modal/MyPageModal.tsx
@@ -1,9 +1,12 @@
 import GooGleSVG from "@/assets/images/googleIcon.svg?react";
 import KakaoSVG from "@/assets/images/socialLogin/kakaoLogin.svg?react";
 import NaverSVG from "@/assets/images/socialLogin/naverLogin.svg?react";
+import useModal from "@/hooks/useModal";
 import styled from "styled-components";
 import Title from "../common/Title";
+import Modal from "./Modal";
 import MyPageItem from "./MyPageItem";
+import UserDelete from "./UserDelete";
 import XButton from "./XButton";
 
 interface Props {
@@ -11,6 +14,12 @@ interface Props {
 }
 
 const MyPageModal = ({ onClose }: Props) => {
+  const {
+    isOpen: isDeleteOpen,
+    modalOpen: deleteModalOpen,
+    modalClose: deleteModalClose
+  } = useModal(false);
+
   return (
     <MyPageModalStyle>
       <div className="modal-header">
@@ -57,7 +66,14 @@ const MyPageModal = ({ onClose }: Props) => {
             isConnected={false}
           ></MyPageItem>
         </div>
-        <button className="delete">회원탈퇴</button>
+        <button className="delete" onClick={deleteModalOpen}>
+          회원탈퇴
+        </button>
+        {isDeleteOpen && (
+          <Modal onClose={deleteModalClose}>
+            <UserDelete onClose={deleteModalClose} />
+          </Modal>
+        )}
       </div>
     </MyPageModalStyle>
   );
@@ -69,6 +85,7 @@ const MyPageModalStyle = styled.div`
   background-color: white;
   border-radius: 18px;
   position: relative;
+  z-index: 1000;
 
   .modal-header {
     height: 84px;

--- a/src/components/modal/MyPageModal.tsx
+++ b/src/components/modal/MyPageModal.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import Title from "../common/Title";
 import Modal from "./Modal";
 import MyPageItem from "./MyPageItem";
+import NicknameModal from "./NicknameModal";
 import UserDelete from "./UserDelete";
 import XButton from "./XButton";
 
@@ -18,6 +19,12 @@ const MyPageModal = ({ onClose }: Props) => {
     isOpen: isDeleteOpen,
     modalOpen: deleteModalOpen,
     modalClose: deleteModalClose
+  } = useModal(false);
+
+  const {
+    isOpen: isNicknameOpen,
+    modalOpen: nicknameModalOpen,
+    modalClose: nicknameModalClose
   } = useModal(false);
 
   return (
@@ -35,6 +42,7 @@ const MyPageModal = ({ onClose }: Props) => {
             text="갈라파고스물개"
             buttonText="변경"
             isConnected={true}
+            onClick={nicknameModalOpen}
           ></MyPageItem>
         </div>
         <div className="modal-item">
@@ -72,6 +80,11 @@ const MyPageModal = ({ onClose }: Props) => {
         {isDeleteOpen && (
           <Modal onClose={deleteModalClose}>
             <UserDelete onClose={deleteModalClose} />
+          </Modal>
+        )}
+        {isNicknameOpen && (
+          <Modal onClose={nicknameModalClose}>
+            <NicknameModal onClose={nicknameModalClose} />
           </Modal>
         )}
       </div>

--- a/src/components/modal/MyPageModal.tsx
+++ b/src/components/modal/MyPageModal.tsx
@@ -1,18 +1,23 @@
-import styled from "styled-components";
-import Title from "../common/Title";
+import GooGleSVG from "@/assets/images/googleIcon.svg?react";
 import KakaoSVG from "@/assets/images/socialLogin/kakaoLogin.svg?react";
 import NaverSVG from "@/assets/images/socialLogin/naverLogin.svg?react";
-import GooGleSVG from "@/assets/images/googleIcon.svg?react";
+import styled from "styled-components";
+import Title from "../common/Title";
 import MyPageItem from "./MyPageItem";
 import XButton from "./XButton";
-const MyPageModal = () => {
+
+interface Props {
+  onClose: () => void;
+}
+
+const MyPageModal = ({ onClose }: Props) => {
   return (
     <MyPageModalStyle>
       <div className="modal-header">
         <Title size="T3" color="gray10">
           내 정보 수정
         </Title>
-        <XButton onClose={() => {}} />
+        <XButton onClose={onClose} />
       </div>
       <div className="modal-body">
         <div className="modal-item">
@@ -52,9 +57,7 @@ const MyPageModal = () => {
             isConnected={false}
           ></MyPageItem>
         </div>
-        <div className="modal-item">
-          <button>회원탈퇴</button>
-        </div>
+        <button className="delete">회원탈퇴</button>
       </div>
     </MyPageModalStyle>
   );
@@ -94,5 +97,12 @@ const MyPageModalStyle = styled.div`
       gap: 16px;
     }
   }
+
+  .delete {
+    margin-left: auto;
+    color: ${({ theme }) => theme.color.gray8};
+    text-decoration: underline;
+  }
 `;
+
 export default MyPageModal;

--- a/src/components/modal/NicknameModal.tsx
+++ b/src/components/modal/NicknameModal.tsx
@@ -1,0 +1,75 @@
+import styled from "styled-components";
+import Button from "../common/Button";
+import Input from "../common/Input";
+import Title from "../common/Title";
+import XButton from "./XButton";
+
+interface Props {
+  onClose: () => void;
+}
+
+const NicknameModal = ({ onClose }: Props) => {
+  return (
+    <NicknameModalStyle>
+      <div className="nickname-header">
+        <Title size="T6" color="gray10">
+          닉네임 변경
+        </Title>
+        <XButton onClose={onClose} className="close-button" />
+      </div>
+      <div className="nickname-body">
+        <Input unit={"8/15"} placeholder={"갈라파고스물개"} />
+        <ButtonWrapper>
+          <Button schema={"inactivated"} size="wideMedium">
+            변경
+          </Button>
+        </ButtonWrapper>
+      </div>
+    </NicknameModalStyle>
+  );
+};
+
+const NicknameModalStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 412px;
+  background-color: white;
+  border-radius: ${({ theme }) => theme.borderRadius.default};
+
+  position: relative;
+  z-index: 2000;
+
+  .nickname-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 60px;
+    padding: 14px 22px;
+    border-bottom: 1px solid ${({ theme }) => theme.color.gray3};
+
+    .close-button {
+      margin-right: auto;
+    }
+  }
+  .nickname-body {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 22px;
+    input {
+      width: 100%;
+    }
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  display: flex;
+  justify-content: end;
+  height: 48px;
+
+  button {
+    width: 108px;
+    height: 100%;
+  }
+`;
+export default NicknameModal;

--- a/src/components/modal/SocialLoginModal.tsx
+++ b/src/components/modal/SocialLoginModal.tsx
@@ -13,7 +13,6 @@ const SocialLoginModal = ({ onClose }: Props) => {
   const handleLoginCode = (type: ToauthType) => {
     requestLoginCode(type)
       .then((res) => {
-        console.log(`⭕ request login code 성공!`);
         window.location.href = res.data.oauthLink;
       })
       .catch((err) => {

--- a/src/components/modal/UserDelete.tsx
+++ b/src/components/modal/UserDelete.tsx
@@ -1,0 +1,68 @@
+import styled from "styled-components";
+import Body from "../common/Body";
+import Button from "../common/Button";
+import Title from "../common/Title";
+
+interface Props {
+  onClose: () => void;
+}
+
+const UserDelete = ({ onClose }: Props) => {
+  return (
+    <Wrapper>
+      <Title size="T6" color="gray10" className="center title">
+        회원님, 정말 탈퇴하시겠어요?
+      </Title>
+      <Body size="B3" color="#6D6D7D" className="center body">
+        탈퇴 즉시 모든 정보가 삭제되며, 데이터 복구가 불가해요
+        <br />
+        SNS 계정 연결 해지를 위해 로그인이 필요할 수 있으며, <br />
+        재가입은 탈퇴일로부터 30일 후 가능해요
+      </Body>
+      <Buttons>
+        <Button size="wideMedium" schema="default" onClick={onClose}>
+          취소
+        </Button>
+        <Button size="wideMedium" schema="activated">
+          탈퇴
+        </Button>
+      </Buttons>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 412px;
+  padding: 36px 22px;
+  background-color: white;
+  border-radius: ${({ theme }) => theme.borderRadius.default};
+
+  position: relative;
+  z-index: 2000;
+
+  .title {
+    margin-bottom: 8px;
+  }
+  .body {
+    margin-bottom: 24px;
+  }
+
+  .center {
+    text-align: center;
+  }
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  height: 48px;
+
+  button {
+    height: 100%;
+    flex: 1;
+  }
+`;
+export default UserDelete;

--- a/src/pages/Test.tsx
+++ b/src/pages/Test.tsx
@@ -4,7 +4,6 @@ import SnbMarketSVG from "@/assets/images/SnbMarket.svg?react";
 import SnbMockInvestSVG from "@/assets/images/SnbMockInvest.svg?react";
 import BasicSetup from "@/components/backtesting/BasicSetup";
 import NavBar from "@/components/common/navbar/NavBar";
-import MyPageModal from "@/components/modal/MyPageModal";
 import styled from "styled-components";
 import BackTestingResult from "./BackTestingResult";
 export const SNB_ITEM = [
@@ -24,7 +23,6 @@ const Test = () => {
       <Page>
         <BasicSetup />
         <BackTestingResult />
-        <MyPageModal></MyPageModal>
       </Page>
     </TestStyle>
   );

--- a/src/style/global.ts
+++ b/src/style/global.ts
@@ -28,6 +28,15 @@ const GlobalStyle = createGlobalStyle`
         padding: 0;
     }
 
+    button {
+        margin: 0;
+        padding: 0;
+        border: none;
+        outline: none;
+        background: inherit;
+        font-family: inherit;
+        cursor: pointer;
+    }
     
 `;
 


### PR DESCRIPTION
# Pull requests
### ✅ 작업한 내용
- 내 정보 수정 > 닉네임 변경 및 회원탈퇴 모달 띄우는 작업입니다.

### ❗️PR Point
- 피그마의 SNB 섹션의 있는 내용이며, 이외에 '한투연동', '계정연동' 부분은 백엔드 API가 없어서 만들지 않았습니다

### 📸 스크린샷

https://github.com/user-attachments/assets/15e9751c-ecfc-4079-a903-1b517535a881

closed #46 
